### PR TITLE
Don't include unsupported user in connection URL

### DIFF
--- a/API.md
+++ b/API.md
@@ -74,7 +74,7 @@ var redisOnPort6380 = new Redis(6380);
 var anotherRedis = new Redis(6380, '192.168.100.1');
 var unixSocketRedis = new Redis({ path: '/tmp/echo.sock' });
 var unixSocketRedis2 = new Redis('/tmp/echo.sock');
-var urlRedis = new Redis('redis://user:password@redis-service.com:6379/');
+var urlRedis = new Redis('redis://:password@redis-service.com:6379/');
 var urlRedis2 = new Redis('//localhost:6379');
 var authedRedis = new Redis(6380, '192.168.100.1', { password: 'password' });
 ```


### PR DESCRIPTION
After an hour of confusion about why a username is supported in the URL format but not the options hash, I finally discovered that Redis doesn't support multi-user auth at all. This change should make the docs less confusing to folks new to Redis.